### PR TITLE
Use Super key as an additional optional modifier

### DIFF
--- a/com.tobiasquinn.mousewheelzoom.gschema.xml
+++ b/com.tobiasquinn.mousewheelzoom.gschema.xml
@@ -11,6 +11,11 @@
             <summary>Modifier key to enable mousewheel zooming</summary>
             <description>This list is the modifier to be used in conjunction with the mousewheel for zooming. Possible values are 'alt', 'ctrl', 'shift'.</description>
         </key>
+        <key type="b" name="super-key">
+            <default>true</default>
+            <summary>Whether to include super key in modifier</summary>
+            <description>If this is checked, the super key must be pressed in addition to whatever other modifier key is used.</description>
+        </key>
     </schema>
 </schemalist>
 

--- a/mousewheelzoom.vala
+++ b/mousewheelzoom.vala
@@ -130,6 +130,8 @@ void main(string[] arg) {
     // load appropriate key from dconf configuration
     var settings = new Settings("com.tobiasquinn.mousewheelzoom");
     string key = settings.get_string("modifier-key");
+    bool super_key = settings.get_boolean("super-key");
+
     // default to ALT as modifier
     int keymask = X.KeyMask.Mod1Mask;
     switch (key) {
@@ -140,6 +142,11 @@ void main(string[] arg) {
             keymask = X.KeyMask.ShiftMask;
             break;
     }
+
+    if (super_key) {
+        keymask = keymask | X.KeyMask.Mod4Mask;
+    }
+
     // grab the chosen key and scrollwheel
     X.Display disp = new X.Display();
     X.Window root = disp.default_root_window();


### PR DESCRIPTION
- Add a boolean setting for super key
- Check super key setting when constructing a keymask

Scratching a bit of a personal itch, I like all my desktop-wide shortcuts to incorporate the super key, so that there's less chance of collision with individual applications.

It seems Super key is often mod4 (http://blacketernal.wordpress.com/set-up-key-mappings-with-xmodmap/)
