### PR TITLE
Small fixes for mousewheelzoom.py, change to META key

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ gnome-shell-mousewheel-zoom
 GPLv3
 
 This uses python-xlib and python-dbus to allow the gnome shell to be zoomed
-like enhanced zoom desktop in compiz using the alt modifier and mouse scrollwheel
+like enhanced zoom desktop in compiz using the meta modifier and mouse scrollwheel
 
 There is an archlinux PKGBUILD provided (available from AUR as gnome-shell-mousewheel-zoom-git)
 
@@ -20,5 +20,9 @@ sudo apt-get update
 sudo apt-get install gnome-shell-mousewheel-zoom
 
 There is a ppa for Ubuntu precise availble from the same place. This is the
-precise branch which is a port to vala. There is also a precise port using
-gsetting in the branch precise-gsettings.
+precise-gsettings branch which uses gsetting. There is also precise port to vala.
+
+## Notes
+`Xlib.error.DisplayConnectionError: Can't connect to display ":0": b'No protocol specified\n'`
+If you get this error, run `xhost '+si:localuser:USERNAME'` as a temporaly solution.
+

--- a/mousewheelzoom.py
+++ b/mousewheelzoom.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # gnome-shell-mousewheel-zoom
 
@@ -24,7 +24,7 @@ class Zoomer:
     def __init__(self):
         self._app_settings = Gio.Settings.new(APP_BASE_KEY)
         self._mag_settings = Gio.Settings.new(MAG_BASE_KEY)
-        self._app_settings.set_boolean("screen-magnifier-enabled", False)
+        self._app_settings.set_boolean("screen-magnifier-enabled", True)
         self._active = False
         self._currentZoom = self._mag_settings.get_double("mag-factor")
 
@@ -56,7 +56,7 @@ def main():
     for mask in masks:
         for button in buttons:
             root.grab_button(button,
-                    X.Mod1Mask | mask,
+                    X.Mod4Mask | mask,
                     root,
                     False,
                     X.GrabModeAsync,

--- a/mousewheelzoom.py.desktop
+++ b/mousewheelzoom.py.desktop
@@ -1,8 +1,7 @@
-
 [Desktop Entry]
 Type=Application
 Exec=/usr/bin/mousewheelzoom.py
 Hidden=false
 OnlyShowIn=GNOME;
 Name=Mouse Wheel Zoom
-Comment=Zoom using mouse wheel and Left-Alt key
+Comment=Zoom using mouse wheel and Meta key


### PR DESCRIPTION
Hello Tobias, 

first of all I'd like to thank you for your program - it improves my working experience a lot!

I see the last change is several years old, but it still works and I did just minor improvements:
* Change from ALT to META - it was in collision with Firefox
* Document python-xlib bug - when the application refuses to start
* Fix the initial state - my magnifier it was disabling magnifier while initiating itself
* Use python3 - I was getting weird errors and majority of software already switched to python3

I'd also like to package it for (open)SUSE where I already use it.